### PR TITLE
Change the proposed way to run the quiz via docker

### DIFF
--- a/sites/hurl.dev/_docs/tutorial/your-first-hurl-file.md
+++ b/sites/hurl.dev/_docs/tutorial/your-first-hurl-file.md
@@ -46,7 +46,7 @@ just run in a shell:
 
 ```
 $ docker pull ghcr.io/jcamiel/quiz:latest
-$ docker run -dp 8080:8080 ghcr.io/jcamiel/quiz:latest
+$ docker run --name hurl-quiz --rm --detach --publish 8080:8080 ghcr.io/jcamiel/quiz:latest
 ```
 
 And check that the container is running with:


### PR DESCRIPTION
- use long names of arguments because it's more clear what they do
- auto remove the container on exit
- give the container an explicit name

The repository does not have the `hacktoberfest` label, if you don't want to add it to avoid spam, I would be happy if you could set the `hacktoberfest-accepted` label on the PR :)