### PR TITLE
Add npm installation instructions

### DIFF
--- a/sites/hurl.dev/_docs/installation.md
+++ b/sites/hurl.dev/_docs/installation.md
@@ -88,6 +88,12 @@ $ cargo install hurl
 $ docker pull orangeopensource/hurl
 ```
 
+### npm
+
+```shell
+$ npm install --save-dev @orangeopensource/hurl
+```
+
 ## Building From Sources
 
 Hurl sources are available in [GitHub].


### PR DESCRIPTION
I'm working on a blog post about how to use Hurl with node.js projects, and noticed that there isn't any information about being able to install it via `npm` now.  I've added a section to the Installation page.