### PR TITLE
Use 1.1 vs. 1.0 for HTTP version on example.net

### DIFF
--- a/sites/hurl.dev/_docs/asserting-response.md
+++ b/sites/hurl.dev/_docs/asserting-response.md
@@ -16,7 +16,7 @@ Protocol version is one of `HTTP/1.0`, `HTTP/1.1`, `HTTP/2` or
 ```hurl
 GET http://example.net/404.html
 
-HTTP/1.0 404
+HTTP/1.1 404
 ```
 
 Wildcard keywords (`HTTP/*`, `*`) can be used to disable tests on protocol version and status:


### PR DESCRIPTION
While writing my post this week, I noticed that the [first example assertion in the docs](https://hurl.dev/docs/asserting-response.html) is using `HTTP/1.0`, but the actual response is `HTTP/1.1`:

```sh
$ curl -I http://example.net/404.html
HTTP/1.1 404 Not Found
Content-Encoding: gzip
Accept-Ranges: bytes
Age: 169708
Cache-Control: max-age=604800
Content-Type: text/html; charset=UTF-8
Date: Wed, 18 May 2022 16:48:34 GMT
Expires: Wed, 25 May 2022 16:48:34 GMT
Last-Modified: Mon, 16 May 2022 17:40:06 GMT
Server: ECS (chb/02C0)
X-Cache: 404-HIT
Content-Length: 648
```

This fixes it so that people who are copy/pasting can get a working test immediately.